### PR TITLE
feat: add central LLM request dispatcher

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,6 +1,7 @@
 import { TextChannel } from 'discord.js'
-import { event, Events, normalMessage, UserMessage, clean, blockResponse } from '../utils/index.js'
+import { event, Events, normalMessage, UserMessage, clean } from '../utils/index.js'
 import Keys from '../keys.js'
+import { requestDispatcher } from '../queues/requestDispatcher.js'
 import {
     getChannelInfo, getServerConfig, getChannelConfig, openChannelInfo,
     openConfig, openConfigMultiple, ChannelConfig, ServerConfig, getAttachmentData, getTextFileAttachmentData
@@ -14,6 +15,7 @@ import {
  */
 export default event(Events.MessageCreate, async ({ log, ollama, client, defaultModel }, message) => {
     const clientId = client.user!!.id
+    const DISPATCH_TIMEOUT = 15000 // milliseconds to wait in queue before failing
     let cleanedMessage = clean(message.content, clientId)
     if (cleanedMessage.length < 5) return // ignore messages that are too short after cleaning
     log(`Message \"${cleanedMessage}\" from ${message.author.tag} in channel/thread ${message.channelId}.`)
@@ -209,11 +211,11 @@ export default event(Events.MessageCreate, async ({ log, ollama, client, default
                 }
             ]
             // Summarize the messages
-            const summary = await blockResponse({
+            const summary = await requestDispatcher.blockResponse({
                 model: finalModel,
                 ollama: ollama,
                 msgHist: summarizer_prompt
-            })
+            }, DISPATCH_TIMEOUT)
             // Replace summarized messages with the summary
             channelHistory = [
                 channelHistory[0], // Keep the system prompt
@@ -238,7 +240,14 @@ export default event(Events.MessageCreate, async ({ log, ollama, client, default
         const model: string = finalModel
 
         // response string for ollama to put its response
-        var response: string = await normalMessage(message, ollama, model, channelHistory, shouldStream)
+        var response: string = await normalMessage(
+            message,
+            ollama,
+            model,
+            channelHistory,
+            shouldStream,
+            DISPATCH_TIMEOUT
+        )
 
         // If something bad happened, stop without modifying persisted history
         if (response == undefined) return

--- a/src/queues/requestDispatcher.ts
+++ b/src/queues/requestDispatcher.ts
@@ -1,0 +1,98 @@
+import { ChatResponse } from 'ollama'
+import { AbortableAsyncIterator } from 'ollama/src/utils.js'
+import { blockResponse, streamResponse } from '../utils/handlers/streamHandler.js'
+import { ChatParams } from '../utils/events.js'
+
+export type LLMTask<T> = () => Promise<T>
+
+interface QueueItem<T> {
+    fn: LLMTask<T>
+    resolve: (value: T) => void
+    reject: (reason?: any) => void
+}
+
+/**
+ * Central dispatcher for all LLM requests. Maintains a global queue
+ * and limits the number of concurrent executions.
+ */
+export class RequestDispatcher {
+    private static instance: RequestDispatcher
+    private queue: QueueItem<any>[] = []
+    private active = 0
+
+    // Maximum number of concurrent LLM executions allowed
+    private readonly concurrency: number
+
+    private constructor(concurrency = 2) {
+        this.concurrency = concurrency
+    }
+
+    /**
+     * Access singleton instance
+     */
+    static getInstance(concurrency = 2): RequestDispatcher {
+        if (!RequestDispatcher.instance)
+            RequestDispatcher.instance = new RequestDispatcher(concurrency)
+        return RequestDispatcher.instance
+    }
+
+    /**
+     * Enqueue a task for execution. If the task is not picked up within the
+     * provided timeout, it will reject with a rate limit error.
+     * @param fn async task to execute
+     * @param timeout time in ms to wait before rejecting
+     */
+    private enqueue<T>(fn: LLMTask<T>, timeout = 10000): Promise<T> {
+        return new Promise<T>((resolve, reject) => {
+            let timer: NodeJS.Timeout
+            const item: QueueItem<T> = {
+                fn,
+                resolve: (val: T) => { clearTimeout(timer); resolve(val) },
+                reject: (err: any) => { clearTimeout(timer); reject(err) }
+            }
+
+            // timeout for waiting in queue
+            timer = setTimeout(() => {
+                const idx = this.queue.indexOf(item)
+                if (idx !== -1) {
+                    this.queue.splice(idx, 1)
+                    item.reject(new Error('Rate limit exceeded: request timed out while waiting in queue.'))
+                }
+            }, timeout)
+
+            this.queue.push(item)
+            this.process()
+        })
+    }
+
+    /**
+     * Request a non-streaming LLM response through the dispatcher
+     */
+    async blockResponse(params: ChatParams, timeout = 10000): Promise<ChatResponse> {
+        return this.enqueue(() => blockResponse(params), timeout)
+    }
+
+    /**
+     * Request a streaming LLM response through the dispatcher
+     */
+    async streamResponse(params: ChatParams, timeout = 10000): Promise<AbortableAsyncIterator<ChatResponse>> {
+        return this.enqueue(() => streamResponse(params), timeout)
+    }
+
+    private process(): void {
+        while (this.active < this.concurrency && this.queue.length > 0) {
+            const item = this.queue.shift()!
+            this.active++
+            item.fn()
+                .then(res => item.resolve(res))
+                .catch(err => item.reject(err))
+                .finally(() => {
+                    this.active--
+                    this.process()
+                })
+        }
+    }
+}
+
+// Export a default singleton for convenience
+export const requestDispatcher = RequestDispatcher.getInstance()


### PR DESCRIPTION
## Summary
- expose `blockResponse` and `streamResponse` helpers on the dispatcher to centrally queue LLM calls
- route normal message generation and history summaries through dispatcher with explicit timeouts

## Testing
- `npm run tests` *(fails: Environment variable CLIENT_TOKEN is not set.)*

------
https://chatgpt.com/codex/tasks/task_e_68afb3b1a37c83288cefed96b7484d8f